### PR TITLE
feat: Cleanup Test Classes and Dependencies - Meeds-io/MIPs#42 - EXO-62860

### DIFF
--- a/mail-integration-api/pom.xml
+++ b/mail-integration-api/pom.xml
@@ -28,23 +28,5 @@
   </dependencies>
   <build>
     <finalName>mail-integration-api</finalName>
-    <plugins>
-      <plugin>
-        <groupId>org.projectlombok</groupId>
-        <artifactId>lombok-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>delombok</goal>
-            </goals>
-            <configuration>
-              <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
-              <addOutputDirectory>false</addOutputDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
 </project>

--- a/mail-integration-services/pom.xml
+++ b/mail-integration-services/pom.xml
@@ -16,88 +16,19 @@
       <artifactId>mail-integration-api</artifactId>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.exoplatform.social</groupId>
-      <artifactId>social-component-core</artifactId>
+      <artifactId>social-component-service</artifactId>
       <scope>provided</scope>
     </dependency>
-    <!--swagger-->
+
     <dependency>
-      <groupId>io.swagger.core.v3</groupId>
-      <artifactId>swagger-annotations</artifactId>
-      <scope>provided</scope>
+      <groupId>org.exoplatform.social</groupId>
+      <artifactId>social-component-service</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
     </dependency>
-    
-    <dependency>
-      <groupId>org.jsoup</groupId>
-      <artifactId>jsoup</artifactId>
-    </dependency>
-      <!-- Test -->
-      <dependency>
-          <groupId>org.exoplatform.gatein.portal</groupId>
-          <artifactId>exo.portal.component.identity</artifactId>
-          <type>test-jar</type>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.exoplatform.gatein.portal</groupId>
-          <artifactId>exo.portal.component.portal</artifactId>
-          <type>test-jar</type>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.exoplatform.gatein.portal</groupId>
-          <artifactId>exo.portal.component.application-registry</artifactId>
-          <type>test-jar</type>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.exoplatform.commons</groupId>
-          <artifactId>commons-component-common</artifactId>
-          <type>test-jar</type>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.exoplatform.social</groupId>
-          <artifactId>social-component-core</artifactId>
-          <scope>test</scope>
-          <type>test-jar</type>
-      </dependency>
-      <dependency>
-          <groupId>org.exoplatform.commons</groupId>
-          <artifactId>commons-testing</artifactId>
-          <scope>test</scope>
-          <exclusions>
-              <exclusion>
-                  <groupId>junit</groupId>
-                  <artifactId>junit</artifactId>
-              </exclusion>
-              <exclusion>
-                  <groupId>org.exoplatform.tool</groupId>
-                  <artifactId>exo.tool.framework.junit</artifactId>
-              </exclusion>
-          </exclusions>
-      </dependency>
-      <dependency>
-          <groupId>org.mockito</groupId>
-          <artifactId>mockito-core</artifactId>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.powermock</groupId>
-          <artifactId>powermock-module-junit4</artifactId>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>org.powermock</groupId>
-          <artifactId>powermock-api-mockito2</artifactId>
-          <scope>test</scope>
-      </dependency>
-      <dependency>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-          <scope>test</scope>
-      </dependency>
   </dependencies>
   <build>
     <finalName>mail-integration-services</finalName>

--- a/mail-integration-services/src/test/java/org/exoplatform/mailintegration/storage/MailIntegrationStorageTest.java
+++ b/mail-integration-services/src/test/java/org/exoplatform/mailintegration/storage/MailIntegrationStorageTest.java
@@ -21,26 +21,27 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.exoplatform.mailintegration.dao.MailIntegrationDAO;
 import org.exoplatform.mailintegration.entity.MailIntegrationSettingEntity;
 import org.exoplatform.mailintegration.model.MailIntegrationSetting;
 import org.exoplatform.mailintegration.utils.EntityMapper;
 
-import java.util.ArrayList;
-import java.util.List;
-
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "javax.management.*", "javax.xml.*", "org.xml.*" })
+@RunWith(MockitoJUnitRunner.class)
 public class MailIntegrationStorageTest {
+
+  private static final MockedStatic<EntityMapper> ENTITY_MAPPER = Mockito.mockStatic(EntityMapper.class);
+
   private MailIntegrationStorage mailIntegrationStorage;
 
   private MailIntegrationDAO     mailIntegrationDAO;
@@ -51,16 +52,19 @@ public class MailIntegrationStorageTest {
     mailIntegrationStorage = new MailIntegrationStorage(mailIntegrationDAO);
   }
 
-  @PrepareForTest({ EntityMapper.class })
+  @AfterClass
+  public static void afterRunBare() throws Exception { // NOSONAR
+    ENTITY_MAPPER.close();
+  }
+
   @Test
   public void testCreateMailIntegrationSetting() throws Exception { // NOSONAR
     // Given
     MailIntegrationSetting mailIntegrationSetting = createMailIntegrationSetting();
     MailIntegrationSettingEntity mailIntegrationSettingEntity = createMailIntegrationSettingEntity();
     when(mailIntegrationDAO.create(Mockito.any())).thenReturn(mailIntegrationSettingEntity);
-    PowerMockito.mockStatic(EntityMapper.class);
-    when(EntityMapper.toMailIntegrationSettingEntity(mailIntegrationSetting)).thenReturn(mailIntegrationSettingEntity);
-    when(EntityMapper.fromMailIntegrationSettingEntity(mailIntegrationSettingEntity)).thenReturn(mailIntegrationSetting);
+    ENTITY_MAPPER.when(() -> EntityMapper.toMailIntegrationSettingEntity(mailIntegrationSetting)).thenAnswer(invocation -> mailIntegrationSettingEntity);
+    ENTITY_MAPPER.when(() -> EntityMapper.fromMailIntegrationSettingEntity(mailIntegrationSettingEntity)).thenAnswer(invocation -> mailIntegrationSetting);
 
     // When
     MailIntegrationSetting createdMailIntegrationSetting = mailIntegrationStorage.createMailIntegrationSetting(mailIntegrationSetting);
@@ -102,16 +106,14 @@ public class MailIntegrationStorageTest {
     assertEquals(mailIntegrationSettingEntities.size(), retrievedMailIntegrationSettings.size());
   }
 
-  @PrepareForTest({ EntityMapper.class })
   @Test
   public void testUpdateMailIntegrationSetting() throws Exception { // NOSONAR
     // Given
     MailIntegrationSetting mailIntegrationSetting = createMailIntegrationSetting();
     MailIntegrationSettingEntity mailIntegrationSettingEntity = createMailIntegrationSettingEntity();
     when(mailIntegrationDAO.create(Mockito.any())).thenReturn(mailIntegrationSettingEntity);
-    PowerMockito.mockStatic(EntityMapper.class);
-    when(EntityMapper.toMailIntegrationSettingEntity(mailIntegrationSetting)).thenReturn(mailIntegrationSettingEntity);
-    when(EntityMapper.fromMailIntegrationSettingEntity(mailIntegrationSettingEntity)).thenReturn(mailIntegrationSetting);
+    ENTITY_MAPPER.when(() -> EntityMapper.toMailIntegrationSettingEntity(mailIntegrationSetting)).thenAnswer(invocation -> mailIntegrationSettingEntity);
+    ENTITY_MAPPER.when(() -> EntityMapper.fromMailIntegrationSettingEntity(mailIntegrationSettingEntity)).thenAnswer(invocation -> mailIntegrationSetting);
     MailIntegrationSetting createdMailIntegrationSetting = mailIntegrationStorage.createMailIntegrationSetting(mailIntegrationSetting);
     createdMailIntegrationSetting.setAccount("updatedAccount");
     createdMailIntegrationSetting.setEmailName("useraUpdatedMail@exo.tn");

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>addons-parent-pom</artifactId>
     <groupId>org.exoplatform.addons</groupId>
-    <version>16-exo-M06</version>
+    <version>17-exo-M01</version>
   </parent>
   <groupId>org.exoplatform.addons.mail-integration</groupId>
   <artifactId>mail-integration-parent</artifactId>


### PR DESCRIPTION
Prior to this change, the service testing was using powermock which is useless and restrictive in term of third party libraries dependency tree (complex to maintain with Java versions higher than JDK11). In addition, this change will change the Parent POM version to use source **compiled using JDK-17**. The dependency tree has been cleaned up as well to transitively import dependencies for compilation and test scope.