### PR TITLE
fix: fix settings blocks alignement - EXO-62965 (#38)

### DIFF
--- a/mail-integration-webapp/src/main/webapp/vue-app/mail-integration-settings/components/MailIntegrationSettings.vue
+++ b/mail-integration-webapp/src/main/webapp/vue-app/mail-integration-settings/components/MailIntegrationSettings.vue
@@ -17,7 +17,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 <template>
   <v-app v-if="mailIntegrationEnabled && displayed">
     <v-card
-      class="border-radius ma-4"
+      class="border-radius my-4"
       flat>
       <v-list two-line>
         <v-list-item>


### PR DESCRIPTION
this fix is added to remove the extra margins in mail settings block so the settings blocks will be aligned