### PR TITLE
fix: Move eXoResources and eXoSkin Maven Modules from meeds to eXo - Meeds-io/MIPs#52

### DIFF
--- a/mail-integration-webapp/pom.xml
+++ b/mail-integration-webapp/pom.xml
@@ -10,8 +10,8 @@
   <name>eXo Mail Integration - Application</name>
   <dependencies>
     <dependency>
-      <groupId>org.exoplatform.gatein.portal</groupId>
-      <artifactId>exo.portal.web.eXoSkin</artifactId>
+      <groupId>org.exoplatform.commons-exo</groupId>
+      <artifactId>commons-exo.portal.web.eXoSkin</artifactId>
       <classifier>sources</classifier>
       <scope>provided</scope>
     </dependency>
@@ -50,7 +50,7 @@
               <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <includeArtifactIds>exo.portal.web.eXoSkin</includeArtifactIds>
+              <includeArtifactIds>commons-exo.portal.web.eXoSkin</includeArtifactIds>
               <outputDirectory>${project.build.directory}/src/main/webapp</outputDirectory>
             </configuration>
           </execution>


### PR DESCRIPTION
This change will move eXoResources.war and eXoSkin.war resources from gatein-portal to commons-exo