### PR TITLE
fix: Ensure to correctly read the email content

### DIFF
--- a/mail-integration-services/src/main/java/org/exoplatform/mailintegration/service/MailIntegrationServiceImpl.java
+++ b/mail-integration-services/src/main/java/org/exoplatform/mailintegration/service/MailIntegrationServiceImpl.java
@@ -32,6 +32,7 @@ import javax.mail.NoSuchProviderException;
 import javax.mail.Session;
 import javax.mail.Store;
 import javax.mail.UIDFolder;
+import javax.mail.internet.MimeMessage;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -171,7 +172,7 @@ public class MailIntegrationServiceImpl implements MailIntegrationService {
       inbox = store.getFolder("INBOX");
       inbox.open(Folder.READ_ONLY);
       UIDFolder uidInbox = (UIDFolder) inbox;
-      Message message = uidInbox.getMessageByUID(Long.parseLong(messageId));
+      MimeMessage message = (MimeMessage) uidInbox.getMessageByUID(Long.parseLong(messageId));
       messageRestEntity = RestEntityBuilder.fromMessage(message);
       inbox.close(false);
       store.close();

--- a/mail-integration-services/src/main/java/org/exoplatform/mailintegration/utils/RestEntityBuilder.java
+++ b/mail-integration-services/src/main/java/org/exoplatform/mailintegration/utils/RestEntityBuilder.java
@@ -18,6 +18,7 @@ package org.exoplatform.mailintegration.utils;
 
 import javax.mail.*;
 import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
 import org.apache.commons.io.IOUtils;
@@ -68,8 +69,9 @@ public class RestEntityBuilder {
     return mailIntegrationSetting;
   }
 
-  public static final MessageRestEntity fromMessage(Message message) throws MessagingException, IOException {
-    if (message != null) {
+  public static final MessageRestEntity fromMessage(MimeMessage mimeMessage) throws MessagingException, IOException {
+    if (mimeMessage != null) {
+      MimeMessage message = new MimeMessage(mimeMessage);
       MessageRestEntity messageRestEntity = new MessageRestEntity();
       messageRestEntity.setSubject(message.getSubject());
       messageRestEntity.setSentDate(message.getSentDate());

--- a/mail-integration-webapp/src/main/webapp/vue-app/mail-integration-notification/components/MailIntegrationNotification.vue
+++ b/mail-integration-webapp/src/main/webapp/vue-app/mail-integration-notification/components/MailIntegrationNotification.vue
@@ -19,7 +19,7 @@
               color="primary"
               elevation="0"
               small
-              @click="clickMailNotification()">
+              @click.stop="clickMailNotification()">
               <span class="text-none">{{ $t('mailIntegration.notification.button.view') }}</span>
             </v-btn>
           </div>


### PR DESCRIPTION
Before this fix, in some cases, the email content was not correctly read due to server response. An error named "Unable to load BODYSTRUCTURE" can be raised To fix that, we read the message by create a new MimeMessage object, which allow to workaround this problem

This commit add also 1 minor fix
- ensure to not launch the click event twice, which display mails twice when user click on button

(cherry picked from commit 8094d16cdd5e8dc154f5c42ee7095a997d79b9e4)